### PR TITLE
Feature/ignored apps UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions are welcome! Here's how to get started.
 
 1. Clone the repository
    ```bash
-   git clone https://github.com/your-username/assula.git
+   git clone https://github.com/mpalazzo02/assula.git
    cd assula
    ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Open-source Vim mode for macOS. Brings Vim-style modal editing to any applicatio
 ### From Source
 
 ```bash
-git clone https://github.com/your-username/assula.git
+git clone https://github.com/mpalazzo02/assula.git
 cd assula
 open Assula.xcodeproj
 ```

--- a/src/App/AppDelegate.swift
+++ b/src/App/AppDelegate.swift
@@ -2,7 +2,6 @@ import Cocoa
 import Combine
 
 class AppDelegate: NSObject, NSApplicationDelegate {
-    private var statusItem: NSStatusItem?
     private var cancellables = Set<AnyCancellable>()
     
     private let vimEngine = VimEngine.shared
@@ -10,7 +9,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let sketchyBarClient = SketchyBarClient.shared
     
     func applicationDidFinishLaunching(_ notification: Notification) {
-        setupStatusBar()
         requestAccessibilityPermissions()
         setupModeObserver()
         startKeyboardMonitor()
@@ -22,77 +20,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     // MARK: - Setup
     
-    private func setupStatusBar() {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        
-        if let button = statusItem?.button {
-            updateStatusBarIcon(for: .insert)
-        }
-        
-        let menu = NSMenu()
-        menu.addItem(NSMenuItem(title: "Assula v0.1.0", action: nil, keyEquivalent: ""))
-        menu.addItem(NSMenuItem.separator())
-        
-        let modeItem = NSMenuItem(title: "Mode: Insert", action: nil, keyEquivalent: "")
-        modeItem.tag = 100
-        menu.addItem(modeItem)
-        
-        menu.addItem(NSMenuItem.separator())
-        menu.addItem(NSMenuItem(title: "Settings...", action: #selector(openSettings), keyEquivalent: ","))
-        menu.addItem(NSMenuItem.separator())
-        menu.addItem(NSMenuItem(title: "Quit Assula", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
-        
-        statusItem?.menu = menu
-    }
-    
-    private func updateStatusBarIcon(for mode: VimMode) {
-        guard let button = statusItem?.button else { return }
-        
-        let symbol: String
-        let color: NSColor
-        
-        switch mode {
-        case .normal:
-            symbol = "N"
-            color = .systemBlue
-        case .insert:
-            symbol = "I"
-            color = .systemGreen
-        case .visual:
-            symbol = "V"
-            color = .systemYellow
-        case .visualLine:
-            symbol = "VL"
-            color = .systemOrange
-        case .operatorPending:
-            symbol = "O"
-            color = .systemPurple
-        }
-        
-        let attributed = NSAttributedString(
-            string: " \(symbol) ",
-            attributes: [
-                .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .bold),
-                .foregroundColor: color
-            ]
-        )
-        button.attributedTitle = attributed
-        
-        // Update menu item
-        if let menu = statusItem?.menu,
-           let modeItem = menu.item(withTag: 100) {
-            modeItem.title = "Mode: \(mode.displayName)"
-        }
-    }
-    
     private func requestAccessibilityPermissions() {
         let options = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as String: true] as CFDictionary
         let trusted = AXIsProcessTrustedWithOptions(options)
         
         if !trusted {
-            print("⚠️ Accessibility permissions not granted. Please enable in System Settings > Privacy & Security > Accessibility")
+            print("[Assula] Accessibility permissions not granted. Please enable in System Settings > Privacy & Security > Accessibility")
         } else {
-            print("✅ Accessibility permissions granted")
+            print("[Assula] Accessibility permissions granted")
         }
     }
     
@@ -100,7 +35,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         vimEngine.$currentMode
             .receive(on: DispatchQueue.main)
             .sink { [weak self] mode in
-                self?.updateStatusBarIcon(for: mode)
                 self?.sketchyBarClient.notifyModeChange(mode)
             }
             .store(in: &cancellables)
@@ -109,16 +43,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func startKeyboardMonitor() {
         do {
             try keyboardMonitor.start()
-            print("✅ Keyboard monitor started")
+            print("[Assula] Keyboard monitor started")
         } catch {
-            print("❌ Failed to start keyboard monitor: \(error)")
+            print("[Assula] Failed to start keyboard monitor: \(error)")
         }
-    }
-    
-    // MARK: - Actions
-    
-    @objc private func openSettings() {
-        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-        NSApp.activate(ignoringOtherApps: true)
     }
 }

--- a/src/App/AssulaApp.swift
+++ b/src/App/AssulaApp.swift
@@ -3,10 +3,134 @@ import SwiftUI
 @main
 struct AssulaApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @StateObject private var vimEngine = VimEngine.shared
+    @StateObject private var menuState = MenuBarState.shared
     
     var body: some Scene {
+        // Menu bar using SwiftUI MenuBarExtra
+        MenuBarExtra {
+            MenuBarMenu()
+        } label: {
+            Text(vimEngine.currentMode.menuBarSymbol)
+                .font(.system(size: 12, weight: .bold, design: .monospaced))
+        }
+        .menuBarExtraStyle(.menu)
+        
         Settings {
             SettingsView()
+        }
+    }
+}
+
+// MARK: - Menu Bar Menu View
+
+struct MenuBarMenu: View {
+    @ObservedObject private var vimEngine = VimEngine.shared
+    @ObservedObject private var menuState = MenuBarState.shared
+    @Environment(\.openSettings) private var openSettings
+    
+    var body: some View {
+        Text("Assula v0.1.0")
+        
+        Divider()
+        
+        Text("Mode: \(vimEngine.currentMode.displayName)")
+        
+        Divider()
+        
+        if !menuState.currentAppBundleId.isEmpty {
+            Button {
+                menuState.toggleCurrentApp()
+            } label: {
+                if menuState.isCurrentAppIgnored {
+                    Text("Enable for \(menuState.currentAppName)")
+                } else {
+                    Text("Disable for \(menuState.currentAppName)")
+                }
+            }
+            
+            Divider()
+        }
+        
+        Button("Settings...") {
+            NSApp.activate(ignoringOtherApps: true)
+            openSettings()
+        }
+        .keyboardShortcut(",", modifiers: .command)
+        
+        Divider()
+        
+        Button("Quit Assula") {
+            NSApplication.shared.terminate(nil)
+        }
+        .keyboardShortcut("q", modifiers: .command)
+    }
+}
+
+// MARK: - Menu Bar State
+
+class MenuBarState: ObservableObject {
+    static let shared = MenuBarState()
+    
+    @Published var currentAppName: String = ""
+    @Published var currentAppBundleId: String = ""
+    @Published var isCurrentAppIgnored: Bool = false
+    
+    private init() {
+        updateCurrentApp()
+        
+        // Observe frontmost app changes
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.updateCurrentApp()
+        }
+    }
+    
+    func updateCurrentApp() {
+        guard let app = NSWorkspace.shared.frontmostApplication,
+              let bundleId = app.bundleIdentifier,
+              bundleId != Bundle.main.bundleIdentifier else {
+            currentAppName = ""
+            currentAppBundleId = ""
+            isCurrentAppIgnored = false
+            return
+        }
+        
+        currentAppName = app.localizedName ?? bundleId
+        currentAppBundleId = bundleId
+        isCurrentAppIgnored = ConfigManager.shared.isAppIgnored(bundleId)
+    }
+    
+    func toggleCurrentApp() {
+        guard !currentAppBundleId.isEmpty else { return }
+        ConfigManager.shared.toggleIgnoredApp(currentAppBundleId)
+        isCurrentAppIgnored = ConfigManager.shared.isAppIgnored(currentAppBundleId)
+    }
+}
+
+// MARK: - VimMode Extensions for Menu Bar
+
+extension VimMode {
+    var menuBarSymbol: String {
+        switch self {
+        case .normal: return " N "
+        case .insert: return " I "
+        case .visual: return " V "
+        case .visualLine: return " VL "
+        case .operatorPending: return " O "
+        }
+    }
+    
+    var menuBarColor: Color {
+        switch self {
+        case .normal: return .blue
+        case .insert: return .green
+        case .visual: return .yellow
+        case .visualLine: return .orange
+        case .operatorPending: return .purple
         }
     }
 }

--- a/src/Core/Config/ConfigManager.swift
+++ b/src/Core/Config/ConfigManager.swift
@@ -59,6 +59,37 @@ class ConfigManager {
         save()
     }
     
+    // MARK: - Ignored Apps Management
+    
+    /// Adds an app to the ignored list
+    func addIgnoredApp(_ bundleId: String) {
+        guard !config.ignoredApps.contains(bundleId) else { return }
+        config.ignoredApps.append(bundleId)
+        save()
+        NotificationCenter.default.post(name: .assulaConfigChanged, object: nil)
+    }
+    
+    /// Removes an app from the ignored list
+    func removeIgnoredApp(_ bundleId: String) {
+        config.ignoredApps.removeAll { $0 == bundleId }
+        save()
+        NotificationCenter.default.post(name: .assulaConfigChanged, object: nil)
+    }
+    
+    /// Checks if an app is in the ignored list
+    func isAppIgnored(_ bundleId: String) -> Bool {
+        config.ignoredApps.contains(bundleId)
+    }
+    
+    /// Toggles an app's ignored status
+    func toggleIgnoredApp(_ bundleId: String) {
+        if isAppIgnored(bundleId) {
+            removeIgnoredApp(bundleId)
+        } else {
+            addIgnoredApp(bundleId)
+        }
+    }
+    
     // MARK: - Helpers
     
     private func createConfigDirectoryIfNeeded() {

--- a/src/UI/SettingsView.swift
+++ b/src/UI/SettingsView.swift
@@ -275,7 +275,7 @@ struct AboutView: View {
             
             Divider()
             
-            Link("View on GitHub", destination: URL(string: "https://github.com/your-username/assula")!)
+            Link("View on GitHub", destination: URL(string: "https://github.com/mpalazzo02/assula")!)
             
             Text("MIT License")
                 .font(.caption2)

--- a/src/UI/SettingsView.swift
+++ b/src/UI/SettingsView.swift
@@ -18,6 +18,11 @@ struct SettingsView: View {
                 Label("General", systemImage: "gear")
             }
             
+            AppsSettingsView()
+                .tabItem {
+                    Label("Apps", systemImage: "app.badge.checkmark")
+                }
+            
             IntegrationsSettingsView()
                 .tabItem {
                     Label("Integrations", systemImage: "puzzlepiece")
@@ -28,7 +33,7 @@ struct SettingsView: View {
                     Label("About", systemImage: "info.circle")
                 }
         }
-        .frame(width: 450, height: 300)
+        .frame(width: 500, height: 380)
     }
 }
 
@@ -66,6 +71,145 @@ struct GeneralSettingsView: View {
             }
         }
         .padding()
+    }
+}
+
+// MARK: - Apps Settings
+
+/// Represents an app with its metadata for display
+struct AppInfo: Identifiable, Hashable {
+    let id: String  // bundle ID
+    let name: String
+    let icon: NSImage?
+    
+    var bundleId: String { id }
+    
+    static func from(bundleId: String) -> AppInfo {
+        // Try to find app info from bundle ID
+        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
+            return from(url: appURL, bundleId: bundleId)
+        }
+        // Fallback: just show bundle ID
+        return AppInfo(id: bundleId, name: bundleId, icon: nil)
+    }
+    
+    static func from(url: URL, bundleId: String? = nil) -> AppInfo {
+        let bundle = Bundle(url: url)
+        let resolvedBundleId = bundleId ?? bundle?.bundleIdentifier ?? url.lastPathComponent
+        let name = bundle?.infoDictionary?["CFBundleName"] as? String
+            ?? bundle?.infoDictionary?["CFBundleDisplayName"] as? String
+            ?? url.deletingPathExtension().lastPathComponent
+        let icon = NSWorkspace.shared.icon(forFile: url.path)
+        
+        return AppInfo(id: resolvedBundleId, name: name, icon: icon)
+    }
+}
+
+struct AppsSettingsView: View {
+    @State private var ignoredApps: [AppInfo] = []
+    @State private var showingFilePicker = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Ignored Applications")
+                .font(.headline)
+            
+            Text("Assula will be completely disabled in these applications.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            
+            // List of ignored apps
+            List {
+                ForEach(ignoredApps) { app in
+                    HStack(spacing: 12) {
+                        // App icon
+                        if let icon = app.icon {
+                            Image(nsImage: icon)
+                                .resizable()
+                                .frame(width: 24, height: 24)
+                        } else {
+                            Image(systemName: "app")
+                                .frame(width: 24, height: 24)
+                        }
+                        
+                        // App name and bundle ID
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(app.name)
+                                .fontWeight(.medium)
+                            Text(app.bundleId)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        
+                        Spacer()
+                        
+                        // Remove button
+                        Button(action: {
+                            removeApp(app.bundleId)
+                        }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Remove from ignored apps")
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .listStyle(.bordered)
+            .frame(minHeight: 150)
+            
+            // Add button
+            HStack {
+                Button(action: {
+                    showingFilePicker = true
+                }) {
+                    Label("Add Application...", systemImage: "plus")
+                }
+                
+                Spacer()
+                
+                Text("\(ignoredApps.count) app\(ignoredApps.count == 1 ? "" : "s") ignored")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .onAppear {
+            loadIgnoredApps()
+        }
+        .fileImporter(
+            isPresented: $showingFilePicker,
+            allowedContentTypes: [.application],
+            allowsMultipleSelection: false
+        ) { result in
+            handleFileSelection(result)
+        }
+    }
+    
+    private func loadIgnoredApps() {
+        let bundleIds = ConfigManager.shared.config.ignoredApps
+        ignoredApps = bundleIds.map { AppInfo.from(bundleId: $0) }
+    }
+    
+    private func removeApp(_ bundleId: String) {
+        ConfigManager.shared.removeIgnoredApp(bundleId)
+        loadIgnoredApps()
+    }
+    
+    private func handleFileSelection(_ result: Result<[URL], Error>) {
+        guard case .success(let urls) = result,
+              let url = urls.first else { return }
+        
+        // Get bundle ID from the selected app
+        guard let bundle = Bundle(url: url),
+              let bundleId = bundle.bundleIdentifier else {
+            print("[Settings] Could not get bundle ID from \(url.path)")
+            return
+        }
+        
+        ConfigManager.shared.addIgnoredApp(bundleId)
+        loadIgnoredApps()
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the ability to manage ignored apps through the UI, making Assula actually usable by allowing users to disable it for specific applications.
### Features
- **Settings > Apps tab**: View and manage ignored applications
  - Displays app icon, name, and bundle ID
  - Add apps via file picker (browse for .app)
  - Remove apps with one click
  
- **Menu bar quick toggle**: "Disable/Enable for [Current App]"
  - Dynamically shows the frontmost app name
  - One-click toggle without opening Settings
- **SwiftUI MenuBarExtra**: Migrated from NSStatusItem
  - Proper `SettingsLink` support for macOS 14+
  - Cleaner SwiftUI-native implementation
### Also includes
- Fix broken GitHub links (your-username → mpalazzo02)
- ConfigManager helper methods for ignored apps management
EOF
)"